### PR TITLE
Handle env vars on frontend

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+---
+version: "3.7"
+services:
+    pastebnn:
+        image: evanofslack/pastebnn:0.1.1
+        environment:
+            APP_PORT: 5000
+            APP_REMOTE_URL: "bin.eslack.net"
+        ports:
+            - "5000:5000"

--- a/web/src/app.d.ts
+++ b/web/src/app.d.ts
@@ -7,3 +7,9 @@ declare namespace App {
 	// interface Error {}
 	// interface Platform {}
 }
+
+declare module '$env/static/public' {
+	export const APP_HOST: string;
+	export const APP_PORT: string;
+	export const APP_REMOTE_URL: string;
+}

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -1,8 +1,0 @@
-import { env } from '$env/dynamic/public';
-
-export const APP_HOST: string = env.APP_HOST ? env.APP_HOST : 'localhost';
-export const APP_PORT: string = env.APP_PORT ? env.APP_PORT : '8080';
-// export const APP_PORT: string = env.APP_PORT;
-export const APP_REMOTE_URL: string = env.APP_REMOTE_URL
-	? env.APP_REMOTE_URL
-	: `${APP_HOST}:${APP_PORT}`;

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
     import type {CreatePaste} from "../../interfaces"
-    import {APP_REMOTE_URL, APP_HOST, APP_PORT} from "../constants"
+    import { APP_REMOTE_URL, APP_HOST, APP_PORT } from '$env/static/public';
 
 
     const expire_times = [
@@ -32,7 +32,6 @@
         };
 
         let res = await fetch(baseURL, requestOptions);
-        let resp = await res.text();
 
         // redirect to paste url
         goto(`/${paste.key}`, { replaceState: false }) 

--- a/web/src/routes/[slug]/+page.svelte
+++ b/web/src/routes/[slug]/+page.svelte
@@ -1,4 +1,3 @@
-
 <script lang='ts'>
     import type { Paste } from '../../../interfaces';
 

--- a/web/src/routes/[slug]/+page.ts
+++ b/web/src/routes/[slug]/+page.ts
@@ -1,6 +1,6 @@
 import type { LoadEvent } from '@sveltejs/kit';
 import type { Paste } from '../../../interfaces';
-import { APP_HOST, APP_PORT } from '../../constants';
+import { APP_HOST, APP_PORT } from '$env/static/public';
 
 export async function load({ fetch, params }: LoadEvent) {
 	const pasteID = params.slug;


### PR DESCRIPTION
Does not actually enable runtime env vars from static deployment. That needs to be addressed in the future